### PR TITLE
[ performance ] Use `SnocList`s and lazyness for a performance boost

### DIFF
--- a/src/Example.idr
+++ b/src/Example.idr
@@ -1,7 +1,7 @@
 module Example
 
+import Data.List1
 import Text.PrettyPrint.Bernardy
-import Data.Maybe
 
 data SExp = SAtom String | SList (List SExp)
 
@@ -25,4 +25,4 @@ opts : LayoutOpts
 opts = Opts 60
 
 main : IO ()
-main = putStrLn $ fromMaybe "ERROR" $ Doc.render opts $ pretty $ generateSExp 7
+main = putStrLn $ Doc.render opts $ pretty $ generateSExp 9

--- a/src/Text/PrettyPrint/Bernardy.idr
+++ b/src/Text/PrettyPrint/Bernardy.idr
@@ -56,7 +56,7 @@ lstats s = let n := length s in MkStats n n 0
 addStats : String -> Stats -> Stats
 addStats s (MkStats ml ll h) = MkStats (max ml $ length s) ll (S h)
 
--- Compare two stats in the precense of a maximal page width.
+-- Compare two stats in the presence of a maximal page width.
 -- We consider a layout `x` to be superior than layout `y`
 -- if
 --   a) the two layouts do not overflow the page and


### PR DESCRIPTION
As noted on discord, with this PR we gain a considerable performance boost. In addition, I tried to annotated exported functions with some doc-strings. Here are some random notes:
* For `Layout`, I used a non-empty `SnocList` instead of a `List1`. We often accumulate documents (and therefore layouts) with a left fold over a list of documents. The natural accumulator for left folds, which guarantees us linear runtime complexity, is the `SnocList`. It just feels more natural here, but that's of course my personal opinion. When I tested it on my system, using `SnocList` instead of `List1` improved performance almost by a factor of 2.
* For the stats, I switched from `Int` to `Nat`. 64bit integer types seem to be slow on the chez backend, because we truncate the results of computations with an integer exceeding the fixnum range. This seems to lead to a considerable slowdown.
* I dropped `replicateTR` and `indentTR`: `replicate` is now tail-recursive, so we can safely use `Data.String.indent` and `Data.String.replicate`.
* Make the `SnocList` in `Layout` lazy. This has a large impact on performance: As long as we try to decide, which layout to print eventually, we are only interested in a layout's statistics, not its line content. We are eventually going to drop all but one layout, so building the lines ahead of time is wasteful. On my system, this improves performance by a factor of 5 - 10.

In addition, I made one small change to the API itself: I personally don't like that we might end up with no layout at all, if all of them overflow the page width. I therefore decided to use a `List1 Layout` in `Doc opt`, and in case of all layouts overflowing, we keep the least wide of them (see also the notes on `compStats`. This means, that rendering a `Doc opts` will always produce a visible result.

Anyway, thanks for this library. It was the first time I came about this style of pretty printing, and I really like the simplicity and elegance of it.