### PR TITLE
[ refactor ] use interface similar to Show

### DIFF
--- a/src/Text/PrettyPrint/Bernardy.idr
+++ b/src/Text/PrettyPrint/Bernardy.idr
@@ -361,13 +361,14 @@ namespace Doc
     sep []        = empty
     sep (x :: xs) = foldl hsep x xs <|> foldl vcat x xs
 
-public export
-interface Pretty a where
-    pretty : {opts : _} -> a -> Doc opts
+--------------------------------------------------------------------------------
+--          Interface
+--------------------------------------------------------------------------------
 
 public export
-interface PrettyPrec prec a | a where
-    prettyPrec : {opts : _} -> prec -> a -> Doc opts
+interface Pretty a where
+    constructor MkPretty
+    prettyPrec : {opts : _} -> Prec -> a -> Doc opts
 
 --------------------------------------------------------------------------------
 --          Utilities


### PR DESCRIPTION
I did not want to include this change in the big performance refactoring, because I'm not sure this redesign of the `Pretty` interface is the way to go. It does make deriving of `Pretty` implementations simpler, though. With this change, `Pretty` is in the spirit of `Show`, with a `prettyPrec : Prec -> a -> Doc opts` function. Unlike with `Show`, function `pretty` is not part of the interface but just an alias for `prettyPrec Open`.

And, no, I'm not going to pester you with PRs every couple of minutes now. I have one final PR in the pipeline, which adds a couple of utility functions, but that should be it, then. :-)