### PR TITLE
[ fixity ] use same fixity for both append operators

### DIFF
--- a/src/Text/PrettyPrint/Bernardy/Combinators.idr
+++ b/src/Text/PrettyPrint/Bernardy/Combinators.idr
@@ -8,7 +8,7 @@ import Text.PrettyPrint.Bernardy.Core
 --------------------------------------------------------------------------------
 --          Symbols
 --------------------------------------------------------------------------------
-    
+
 ||| Creates a single-line document from the given character.
 |||
 ||| @c A printable non-control character.
@@ -141,7 +141,7 @@ brackets = enclose lbrace rbrace
 --          Combining Documents
 --------------------------------------------------------------------------------
 
-infixl 7 <++>
+infixl 8 <++>
 
 ||| Concatenates two documents horizontally with a single space between them.
 export %inline


### PR DESCRIPTION
I don't know if there is a good use case for giving a different fixity to `(<++>)` than to `(<+>)`. Since the current fixity is in conflict with one of another library of mine, I'd like to adjust it here. If you have strong feelings about this, I'll adjust the fixity in my own lib instead.