### PR TITLE
[ compat ] Add export modifier to the exitsting fixity declaration

### DIFF
--- a/src/Text/PrettyPrint/Bernardy/Combinators.idr
+++ b/src/Text/PrettyPrint/Bernardy/Combinators.idr
@@ -141,7 +141,7 @@ brackets = enclose lbracket rbracket
 --          Combining Documents
 --------------------------------------------------------------------------------
 
-infixl 8 <++>
+export infixl 8 <++>
 
 ||| Concatenates two documents horizontally with a single space between them.
 export %inline


### PR DESCRIPTION
Removes current warning and makes sure the code will still work when the default rules to the fixity exporing are changed