### PR TITLE
[ ux ] Don't export name `prf`, as it's widely used and warned about

### DIFF
--- a/src/Text/PrettyPrint/Bernardy/Combinators.idr
+++ b/src/Text/PrettyPrint/Bernardy/Combinators.idr
@@ -238,7 +238,7 @@ export
 sep' : {opts : _} -> List (Doc opts) -> Doc opts
 sep' xs = ifMultiline (hsep xs) (vsep xs)
 
-||| Add the given document only when conditions is true
+||| Add the given document only when condition is true
 export
 when : Bool -> Doc opts -> Doc opts
 when True  = id

--- a/src/Text/PrettyPrint/Bernardy/Core.idr
+++ b/src/Text/PrettyPrint/Bernardy/Core.idr
@@ -94,7 +94,7 @@ record Layout where
     -- natural and efficient accumulator in a left fold.
     content : Lazy (SnocList String)
     stats   : Stats
-    {auto 0 prf : NonEmptySnoc content}
+    {auto 0 prfNonEmptyContent : NonEmptySnoc content}
 
 layout : Lazy (Subset (SnocList String) NonEmptySnoc) -> Stats -> Layout
 layout ss st = MkLayout (fst ss) st @{snd ss}


### PR DESCRIPTION
Compiler produces a warning when some top-level definition is shadowed. All record fields produce top-level getter functions with the same name. Name `prf` is very commonly used as small proof function arguments. Thus, everyone using this library gets lots of shadowing warnings because `Layout` exports a field named `prf`.

I propose to rename this field.